### PR TITLE
适配新版 Codex CLI 的 ChatGPT auth_mode

### DIFF
--- a/src/application/dashboard/buildDashboardState.ts
+++ b/src/application/dashboard/buildDashboardState.ts
@@ -124,7 +124,7 @@ function mapAccount(
     id: account.id,
     displayName: account.accountName?.trim() ?? account.email,
     email: account.email,
-    authMode: account.authMode ?? "oauth",
+    authMode: account.authMode ?? "chatgpt",
     accountName: account.accountName,
     tags: [...(account.tags ?? [])],
     authProviderLabel: formatAuthProvider(account.authProvider, lang),

--- a/src/codex/authFile.ts
+++ b/src/codex/authFile.ts
@@ -52,7 +52,7 @@ export async function readAuthFile(): Promise<CodexAuthFile | undefined> {
  */
 export async function writeAuthFile(tokens: CodexTokens): Promise<void> {
   const authFile: CodexAuthFile = {
-    auth_mode: "oauth",
+    auth_mode: "chatgpt",
     OPENAI_API_KEY: null,
     tokens: {
       id_token: tokens.idToken,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,7 +23,7 @@ export interface CodexTokens {
   accountId?: string;
 }
 
-export type CodexAuthMode = "oauth";
+export type CodexAuthMode = "chatgpt" | "oauth";
 
 /**
  * 配额摘要信息

--- a/src/domain/dashboard/types.ts
+++ b/src/domain/dashboard/types.ts
@@ -297,7 +297,7 @@ export interface DashboardAccountViewModel {
   id: string;
   displayName: string;
   email: string;
-  authMode?: "oauth";
+  authMode?: "chatgpt" | "oauth";
   accountName?: string;
   tags: string[];
   authProviderLabel: string;

--- a/src/storage/aideckCodexStorage.ts
+++ b/src/storage/aideckCodexStorage.ts
@@ -63,7 +63,7 @@ export async function mirrorAideckCodexAccount(account: CodexAccountRecord, toke
       ...existing,
       id: account.id,
       email: account.email.trim().toLowerCase(),
-      auth_mode: readString(existing["auth_mode"]) ?? "oauth",
+      auth_mode: readString(existing["auth_mode"]) ?? "chatgpt",
       user_id: account.userId ?? readString(existing["user_id"]) ?? "",
       plan_type: account.planType ?? readString(existing["plan_type"]) ?? "",
       subscription_active_until:

--- a/src/storage/sharedAccounts.ts
+++ b/src/storage/sharedAccounts.ts
@@ -7,7 +7,7 @@ export function toSharedAccountJson(account: CodexAccountRecord, tokens: CodexTo
   return {
     id: account.id,
     email: account.email,
-    auth_mode: "oauth",
+    auth_mode: "chatgpt",
     user_id: account.userId,
     plan_type: account.planType,
     subscription_active_until: account.subscriptionActiveUntil ?? null,

--- a/test/authMode.test.ts
+++ b/test/authMode.test.ts
@@ -1,0 +1,57 @@
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeAuthFile } from "../src/codex/authFile";
+import type { CodexAccountRecord, CodexTokens } from "../src/core/types";
+import { toSharedAccountJson } from "../src/storage/sharedAccounts";
+
+function createTokens(): CodexTokens {
+  return {
+    idToken: "id-token",
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    accountId: "account-id"
+  };
+}
+
+describe("Codex auth mode compatibility", () => {
+  let tempCodexHome: string;
+  let originalCodexHome: string | undefined;
+
+  beforeEach(async () => {
+    tempCodexHome = await fs.mkdtemp(path.join(os.tmpdir(), "codex-auth-mode-test-"));
+    originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = tempCodexHome;
+  });
+
+  afterEach(async () => {
+    if (originalCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = originalCodexHome;
+    }
+    await fs.rm(tempCodexHome, { recursive: true, force: true });
+  });
+
+  it("writes ChatGPT auth mode to auth.json", async () => {
+    await writeAuthFile(createTokens());
+
+    const authFile = JSON.parse(await fs.readFile(path.join(tempCodexHome, "auth.json"), "utf8"));
+
+    expect(authFile.auth_mode).toBe("chatgpt");
+  });
+
+  it("exports shared accounts with ChatGPT auth mode", () => {
+    const account: CodexAccountRecord = {
+      id: "account",
+      email: "dev@example.com",
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_001_000
+    };
+
+    const shared = toSharedAccountJson(account, createTokens());
+
+    expect(shared.auth_mode).toBe("chatgpt");
+  });
+});


### PR DESCRIPTION
## 摘要

- 将扩展写出的 Codex `auth.json` 从旧的 `auth_mode: "oauth"` 更新为新版 CLI 支持的 `auth_mode: "chatgpt"`
- 同步更新共享账号导出、Aideck 镜像存储默认值和 Dashboard 默认显示值
- 类型层继续保留 `oauth`，用于兼容已导入或历史存储的旧账号记录
- 增加回归测试，覆盖 `auth.json` 写入和共享账号 JSON 导出

## 背景 / 根因

新版 Codex CLI 已不再接受 `auth_mode: "oauth"`，启动时会报错：

```text
unknown variant `oauth`, expected one of `apikey`, `chatgpt`, `chatgptAuthTokens`, `agentIdentity`, `personalAccessToken`
```

当前扩展在切换账号时会重写全局 `auth.json`。如果仍写入旧的 `oauth` variant，Codex CLI 会在读取认证缓存阶段直接启动失败。

## 验证

- `npm test`
- `npm run compile`

备注：`npm run verify` 当前会被仓库现有 ESLint 配置阻塞。当前安装到的是 ESLint 10，它要求 `eslint.config.*`，这不是本次改动引入的问题。
