### PR TITLE
Normalize missing five-hour quota to 100%

### DIFF
--- a/src/utils/quotaWindows.ts
+++ b/src/utils/quotaWindows.ts
@@ -41,7 +41,7 @@ export function normalizeQuotaSummary(summary?: CodexQuotaSummary): CodexQuotaSu
   const resolvedWeekly = classified.weekly ?? (isWeeklyWindow(weeklyWindow) ? weeklyWindow : undefined);
 
   return {
-    hourlyPercentage: resolvedHourly?.percentage ?? 0,
+    hourlyPercentage: resolvedHourly?.percentage ?? 100,
     hourlyResetTime: resolvedHourly?.resetTime,
     hourlyRequestsLeft: resolvedHourly?.requestsLeft,
     hourlyRequestsLimit: resolvedHourly?.requestsLimit,

--- a/test/quotaWindows.test.ts
+++ b/test/quotaWindows.test.ts
@@ -3,6 +3,19 @@ import { normalizeQuotaSummary } from "../src/utils/quotaWindows";
 import { normalizeQuotaColorThresholds } from "../src/utils/ui";
 
 describe("normalizeQuotaSummary", () => {
+  it("normalizes a missing 5-hour window to 100 percent", () => {
+    const normalized = normalizeQuotaSummary({
+      hourlyPercentage: 0,
+      hourlyWindowPresent: false,
+      weeklyPercentage: 72,
+      weeklyWindowMinutes: 10080,
+      weeklyWindowPresent: true
+    });
+
+    expect(normalized?.hourlyPercentage).toBe(100);
+    expect(normalized?.hourlyWindowPresent).toBe(false);
+  });
+
   it("reclassifies swapped hourly and weekly windows by duration", () => {
     const normalized = normalizeQuotaSummary({
       hourlyPercentage: 10,


### PR DESCRIPTION
## Summary

- Normalize an absent 5-hour quota window to `100%` instead of `0%`.
- Keep `hourlyWindowPresent` false so window-aware UI and automation still know the API omitted the window.
- Add regression coverage for weekly-only quota responses.

## Why

When OpenAI returns only the weekly quota window, the normalizer previously substituted `0%` for the missing 5-hour value. The compact status-bar display then showed an incorrect exhausted value even though no 5-hour quota was reported.

## User impact

The existing compact UI format is unchanged and adds no new labels. A weekly-only response now displays `100%` for the missing 5-hour value rather than `0%`.

## Validation

- `npm test` — 119 tests passed
- `npx tsc -p ./ --noEmit` — passed